### PR TITLE
fix ReadWriteMultipleRegister support

### DIFF
--- a/Modbus/IO/ModbusRtuTransport.cs
+++ b/Modbus/IO/ModbusRtuTransport.cs
@@ -66,7 +66,8 @@ internal class ModbusRtuTransport : ModbusSerialTransport
                 Modbus.ReadCoils or
                 Modbus.ReadInputs or
                 Modbus.ReadHoldingRegisters or
-                Modbus.ReadInputRegisters
+                Modbus.ReadInputRegisters or
+                Modbus.ReadWriteMultipleRegisters
                     => frameStart[2] + 1,
 
                 Modbus.WriteSingleCoil or

--- a/Modbus/Message/AbstractModbusMessage.cs
+++ b/Modbus/Message/AbstractModbusMessage.cs
@@ -39,7 +39,7 @@ public abstract class AbstractModbusMessage
         set => MessageImpl.SlaveAddress = value;
     }
 
-    public byte[] MessageFrame =>
+    public virtual byte[] MessageFrame =>
         MessageImpl.MessageFrame;
 
     public virtual byte[] ProtocolDataUnit =>

--- a/Modbus/Message/ReadWriteMultipleRegistersRequest.cs
+++ b/Modbus/Message/ReadWriteMultipleRegistersRequest.cs
@@ -28,6 +28,20 @@ public class ReadWriteMultipleRegistersRequest : AbstractModbusMessage, IModbusR
             writeData);
     }
 
+    public override byte[] MessageFrame
+    {
+        get
+        {
+            byte[]? pdu = ProtocolDataUnit;
+            MemoryStream frame = new(1 + pdu.Length);
+
+            frame.WriteByte(SlaveAddress);
+            frame.Write(pdu, 0, pdu.Length);
+
+            return frame.ToArray();
+        }
+    }
+
     public override byte[] ProtocolDataUnit
     {
         get


### PR DESCRIPTION
ReadWriteMultipleRegister support is not working, because the generated frame is incomplete.
The frame is created by ModbusMessageImpl.MessageFrame, which calls ModbusMessageImpl.ProtocolDataUnit internally, instead of the overridden ReadWriteMultipleRegisterRequest.ProtocolDataUnit.
By overriding ModbusMessageImpl.MessageFrame in ReadWriteMultipleRegisterRequest (duplicating the implementation, there might be a better solution), the generated ReadWriteMultipleRegister frame will be correct.
After fixing this, I found that the response is rejected, because ReadWriteMultipleRegisters was is not in the functionCode switch.

These commits result in working ReadWriteMultipleRegister support (tested with RTU)